### PR TITLE
[Doppins] Upgrade dependency raven to ^0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "moment": "^2.12.0",
     "morgan": "~1.7.0",
     "q": "^1.4.1",
-    "raven": "^0.12.0",
+    "raven": "^0.12.1",
     "semantic-ui-css": "^2.1.8",
     "sequelize": "^3.13.0",
     "serve-favicon": "~2.3.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "moment": "^2.12.0",
     "morgan": "~1.7.0",
     "q": "^1.4.1",
-    "raven": "^0.11.0",
+    "raven": "^0.12.0",
     "semantic-ui-css": "^2.1.8",
     "sequelize": "^3.13.0",
     "serve-favicon": "~2.3.0",


### PR DESCRIPTION
Hi!

A new version was just released of `raven`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded raven from `^0.11.0` to `^0.12.0`

